### PR TITLE
Improve & document testing changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,3 +32,6 @@ indent_size = 2
 [.editorconfig]
 indent_style = space
 indent_size = 4
+
+[*.md]
+trim_trailing_whitespace=false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,17 +7,6 @@ Refer to the Denizen contribution guide: https://github.com/DenizenScript/Denize
 
 You will be using the `runClient` task to run a Minecraft client with Clientizen from within the IDE.  
 As the client that task runs does not include authentication by default, Clientizen makes use of the `DevAuth` mod to do that.  
-All you need to do to set up `DevAuth` is create its config file, you will want to place it in `C:\Users\<User>\.devauth\config.toml`, with the following contents
-```toml
-defaultEnabled = true
-defaultAccount = "main"
-
-[accounts.main]
-type = "microsoft"
-```
-This will enable `DevAuth` and make it use a Microsoft account by default.  
-
----
-Now that you have `DevAuth` setup, you can go into your IDE, select `Minecraft Client` from the run menu at the top bar and press run.
+Go into your IDE, select `Clientizen [runClient]` from the run menu at the top bar and press run.
 Note the run terminal opening below, where `DevAuth` will output a link for you to authenticate your Microsoft account.  
-You should only need to do that once (and after the token expires, which seems to be about 90 days according to the author).
+You should only need to do that once (and after the token expires, which seems to be about 90 days according to the author), after that you will be able to simply run the `runClient` task to start a Minecraft client with Clientizen.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,3 +2,22 @@ Contribution to Denizen
 -----------------------
 
 Refer to the Denizen contribution guide: https://github.com/DenizenScript/Denizen/blob/dev/CONTRIBUTING.md
+
+## Testing changes
+
+You will be using the `runClient` task to run a Minecraft client with Clientizen from within the IDE.  
+As the client that task runs does not include authentication by default, Clientizen makes use of the `DevAuth` mod to do that.  
+All you need to do to set up `DevAuth` is create its config file, you will want to place it in `C:\Users\<User>\.devauth\config.toml`, with the following contents
+```toml
+defaultEnabled = true
+defaultAccount = "main"
+
+[accounts.main]
+type = "microsoft"
+```
+This will enable `DevAuth` and make it use a Microsoft account by default.  
+
+---
+Now that you have `DevAuth` setup, you can go into your IDE, select `Minecraft Client` from the run menu at the top bar and press run.
+Note the run terminal opening below, where `DevAuth` will output a link for you to authenticate your Microsoft account.  
+You should only need to do that once (and after the token expires, which seems to be about 90 days according to the author).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Refer to the Denizen contribution guide: https://github.com/DenizenScript/Denize
 
 The instructions below are targeted at the `Intellij IDEA` IDE, although the process should be similar for most IDEs.  
 You will be using the `Minecraft Client` run configuration to run a Minecraft client with Clientizen from within your IDE; as the client that runs does not include authentication by default, Clientizen makes use of the `DevAuth` mod to enable that.  
-Go into your IDE, select the `Minecraft Client` run configuration from the run menu at the top bar (if it's missing, restart your IDE), and press run.  
+Go into your IDE, select the `Minecraft Client` run configuration from the run menu at the top bar (if it's missing, restart your IDE or run the `ideaSyncTask` Gradle task), and press run.  
 Note the run terminal opening below, where `DevAuth` will output a link for you to authenticate your Microsoft account.  
 You should only need to do that once (and after the token expires, which seems to be about 90 days according to the `DevAuth` developer), after that you will be able to simply run the `Minecraft Client` run configuration to start a Minecraft client with Clientizen.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Refer to the Denizen contribution guide: https://github.com/DenizenScript/Denize
 
 ## Testing changes
 
-You will be using the `runClient` task to run a Minecraft client with Clientizen from within the IDE.  
+You will be using the `Minecraft Client` run configuration to run a Minecraft client with Clientizen from within your IDE.  
 As the client that task runs does not include authentication by default, Clientizen makes use of the `DevAuth` mod to do that.  
-Go into your IDE, select `Clientizen [runClient]` from the run menu at the top bar and press run.
+Go into your IDE, select `Minecraft Client` from the run menu at the top bar, and press run.
 Note the run terminal opening below, where `DevAuth` will output a link for you to authenticate your Microsoft account.  
-You should only need to do that once (and after the token expires, which seems to be about 90 days according to the `DevAuth` developer), after that you will be able to simply run the `runClient` task to start a Minecraft client with Clientizen.
+You should only need to do that once (and after the token expires, which seems to be about 90 days according to the `DevAuth` developer), after that you will be able to simply run the `Minecraft Client` run configuration to start a Minecraft client with Clientizen.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,10 @@ Refer to the Denizen contribution guide: https://github.com/DenizenScript/Denize
 
 ## Testing changes
 
-You will be using the `Minecraft Client` run configuration to run a Minecraft client with Clientizen from within your IDE.  
-As the client that task runs does not include authentication by default, Clientizen makes use of the `DevAuth` mod to do that.  
-Go into your IDE, select `Minecraft Client` from the run menu at the top bar, and press run.
+The instructions below are targeted at the `Intellij IDEA` IDE, although the process should be similar for most IDEs.  
+You will be using the `Minecraft Client` run configuration to run a Minecraft client with Clientizen from within your IDE; as the client that runs does not include authentication by default, Clientizen makes use of the `DevAuth` mod to enable that.  
+Go into your IDE, select the `Minecraft Client` run configuration from the run menu at the top bar (if it's missing, restart your IDE), and press run.  
 Note the run terminal opening below, where `DevAuth` will output a link for you to authenticate your Microsoft account.  
 You should only need to do that once (and after the token expires, which seems to be about 90 days according to the `DevAuth` developer), after that you will be able to simply run the `Minecraft Client` run configuration to start a Minecraft client with Clientizen.
+
+For more information regarding setup in specific IDEs, preferred settings, and generating & reading Minecraft sources, see [Fabric's docs](https://fabricmc.net/wiki/tutorial:setup#intellij_idea).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,4 +9,4 @@ You will be using the `runClient` task to run a Minecraft client with Clientizen
 As the client that task runs does not include authentication by default, Clientizen makes use of the `DevAuth` mod to do that.  
 Go into your IDE, select `Clientizen [runClient]` from the run menu at the top bar and press run.
 Note the run terminal opening below, where `DevAuth` will output a link for you to authenticate your Microsoft account.  
-You should only need to do that once (and after the token expires, which seems to be about 90 days according to the author), after that you will be able to simply run the `runClient` task to start a Minecraft client with Clientizen.
+You should only need to do that once (and after the token expires, which seems to be about 90 days according to the `DevAuth` developer), after that you will be able to simply run the `runClient` task to start a Minecraft client with Clientizen.

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,15 @@ dependencies {
     modRuntimeOnly("me.djtheredstoner:DevAuth-fabric:${project.devauth_version}")
 }
 
+loom {
+    runs {
+        named("client") {
+            property("devauth.enabled", "true")
+            property("devauth.account", "alt") // DevAuth's name for the Microsoft account in the default config
+        }
+    }
+}
+
 
 processResources {
     inputs.property "version", version

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
 loom {
     runs {
-        named("client") {
+        client {
             property("devauth.enabled", "true")
             property("devauth.account", "alt") // DevAuth's name for the Microsoft account in the default config
         }


### PR DESCRIPTION
## Changes

- Sets the `devauth.enabled` property to `true` and the `devauth.account` property to `alt` when using the `Minecraft Client` run configuration, to automatically enable `DevAuth` and use the Microsoft account configured in the default config, I.e. require 0 setup other then actually authenticating the account.
- Adds some basic explanation and instructions about `Minecraft Client` and `DevAuth` to `CONTRIBUTING.md`.