### PR TITLE
Add `EntityTag.is_sneaking` property

### DIFF
--- a/src/main/java/com/denizenscript/clientizen/access/KeyBindingMixinAccess.java
+++ b/src/main/java/com/denizenscript/clientizen/access/KeyBindingMixinAccess.java
@@ -2,7 +2,7 @@ package com.denizenscript.clientizen.access;
 
 public interface KeyBindingMixinAccess {
 
-    void disableUntilPress();
+    void clientizen$disableUntilPress();
 
-    void forceSetPressed(boolean pressed);
+    void clientizen$forceSetPressed(boolean pressed);
 }

--- a/src/main/java/com/denizenscript/clientizen/access/KeyBindingMixinAccess.java
+++ b/src/main/java/com/denizenscript/clientizen/access/KeyBindingMixinAccess.java
@@ -1,0 +1,8 @@
+package com.denizenscript.clientizen.access;
+
+public interface KeyBindingMixinAccess {
+
+    void disableUntilPress();
+
+    void forceSetPressed(boolean pressed);
+}

--- a/src/main/java/com/denizenscript/clientizen/mixin/EventKeyBindingMixin.java
+++ b/src/main/java/com/denizenscript/clientizen/mixin/EventKeyBindingMixin.java
@@ -1,21 +1,18 @@
 package com.denizenscript.clientizen.mixin;
 
-import com.denizenscript.clientizen.access.KeyBindingMixinAccess;
 import com.denizenscript.clientizen.events.KeyPressReleaseScriptEvent;
 import it.unimi.dsi.fastutil.ints.IntArraySet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(KeyBinding.class)
-public abstract class KeyBindingMixin implements KeyBindingMixinAccess {
+public abstract class EventKeyBindingMixin {
 
-    // Key press release event start
     private static final IntSet pressedKeys = new IntArraySet();
 
     @Inject(method = "setKeyPressed", at = @At("HEAD"))
@@ -32,35 +29,4 @@ public abstract class KeyBindingMixin implements KeyBindingMixinAccess {
             }
         }
     }
-    // Key press release event end
-
-    // Key disabling start
-    boolean clientizen$disabled = false;
-
-    @Override
-    public void disableUntilPress() {
-        clientizen$disabled = true;
-    }
-
-    @Shadow
-    private boolean pressed;
-
-    @Override
-    public void forceSetPressed(boolean pressed) {
-        this.pressed = pressed;
-    }
-
-    @Inject(method = "setPressed", at = @At("HEAD"), cancellable = true)
-    private void clientizen$onSetPressed(boolean pressed, CallbackInfo ci) {
-        if (!clientizen$disabled) {
-            return;
-        }
-        if (pressed || (this instanceof StickyKeyBindingAccessor stickyKeyBindingAccessor && stickyKeyBindingAccessor.getToggleModeChecker().getAsBoolean())) {
-            clientizen$disabled = false;
-        }
-        else {
-            ci.cancel();
-        }
-    }
-    // Key disabling end
 }

--- a/src/main/java/com/denizenscript/clientizen/mixin/KeyBindingMixin.java
+++ b/src/main/java/com/denizenscript/clientizen/mixin/KeyBindingMixin.java
@@ -1,18 +1,21 @@
 package com.denizenscript.clientizen.mixin;
 
+import com.denizenscript.clientizen.access.KeyBindingMixinAccess;
 import com.denizenscript.clientizen.events.KeyPressReleaseScriptEvent;
 import it.unimi.dsi.fastutil.ints.IntArraySet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(KeyBinding.class)
-public class KeyBindingMixin {
+public abstract class KeyBindingMixin implements KeyBindingMixinAccess {
 
+    // Key press release event start
     private static final IntSet pressedKeys = new IntArraySet();
 
     @Inject(method = "setKeyPressed", at = @At("HEAD"))
@@ -29,4 +32,35 @@ public class KeyBindingMixin {
             }
         }
     }
+    // Key press release event end
+
+    // Key disabling start
+    boolean clientizen$disabled = false;
+
+    @Override
+    public void disableUntilPress() {
+        clientizen$disabled = true;
+    }
+
+    @Shadow
+    private boolean pressed;
+
+    @Override
+    public void forceSetPressed(boolean pressed) {
+        this.pressed = pressed;
+    }
+
+    @Inject(method = "setPressed", at = @At("HEAD"), cancellable = true)
+    private void clientizen$onSetPressed(boolean pressed, CallbackInfo ci) {
+        if (!clientizen$disabled) {
+            return;
+        }
+        if (pressed || (this instanceof StickyKeyBindingAccessor stickyKeyBindingAccessor && stickyKeyBindingAccessor.getToggleModeChecker().getAsBoolean())) {
+            clientizen$disabled = false;
+        }
+        else {
+            ci.cancel();
+        }
+    }
+    // Key disabling end
 }

--- a/src/main/java/com/denizenscript/clientizen/mixin/SneakingKeyBindingMixin.java
+++ b/src/main/java/com/denizenscript/clientizen/mixin/SneakingKeyBindingMixin.java
@@ -1,0 +1,41 @@
+package com.denizenscript.clientizen.mixin;
+
+import com.denizenscript.clientizen.access.KeyBindingMixinAccess;
+import net.minecraft.client.option.KeyBinding;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(KeyBinding.class)
+public abstract class SneakingKeyBindingMixin implements KeyBindingMixinAccess {
+
+    boolean clientizen$disabled = false;
+
+    @Override
+    public void clientizen$disableUntilPress() {
+        clientizen$disabled = true;
+    }
+
+    @Shadow
+    private boolean pressed;
+
+    @Override
+    public void clientizen$forceSetPressed(boolean pressed) {
+        this.pressed = pressed;
+    }
+
+    @Inject(method = "setPressed", at = @At("HEAD"), cancellable = true)
+    private void clientizen$onSetPressed(boolean pressed, CallbackInfo ci) {
+        if (!clientizen$disabled) {
+            return;
+        }
+        if (pressed || (this instanceof StickyKeyBindingAccessor stickyKeyBindingAccessor && stickyKeyBindingAccessor.getToggleModeChecker().getAsBoolean())) {
+            clientizen$disabled = false;
+        }
+        else {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/com/denizenscript/clientizen/mixin/StickyKeyBindingAccessor.java
+++ b/src/main/java/com/denizenscript/clientizen/mixin/StickyKeyBindingAccessor.java
@@ -1,0 +1,14 @@
+package com.denizenscript.clientizen.mixin;
+
+import net.minecraft.client.option.StickyKeyBinding;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.function.BooleanSupplier;
+
+@Mixin(StickyKeyBinding.class)
+public interface StickyKeyBindingAccessor {
+
+    @Accessor("toggleGetter")
+    BooleanSupplier getToggleModeChecker();
+}

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
@@ -3,6 +3,7 @@ package com.denizenscript.clientizen.objects.properties;
 import com.denizenscript.clientizen.objects.EntityTag;
 import com.denizenscript.clientizen.objects.ItemTag;
 import com.denizenscript.clientizen.objects.properties.entity.EntitySheared;
+import com.denizenscript.clientizen.objects.properties.entity.EntitySneaking;
 import com.denizenscript.clientizen.objects.properties.item.ItemDurability;
 import com.denizenscript.clientizen.objects.properties.item.ItemServerScript;
 import com.denizenscript.clientizen.objects.properties.material.*;
@@ -26,5 +27,6 @@ public class PropertyRegistry {
 
         // Entity properties
         PropertyParser.registerProperty(EntitySheared.class, EntityTag.class);
+        PropertyParser.registerProperty(EntitySneaking.class, EntityTag.class);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/entity/EntitySneaking.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/entity/EntitySneaking.java
@@ -1,0 +1,56 @@
+package com.denizenscript.clientizen.objects.properties.entity;
+
+import com.denizenscript.clientizen.access.KeyBindingMixinAccess;
+import com.denizenscript.clientizen.objects.EntityTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import net.minecraft.client.MinecraftClient;
+
+public class EntitySneaking extends EntityProperty<ElementTag> {
+
+    // <--[property]
+    // @object EntityTag
+    // @name sneaking
+    // @input ElementTag(Boolean)
+    // @description
+    // Whether an entity is sneaking.
+    // For most entities this just makes the name tag less visible, and doesn't actually update the pose.
+    // -->
+
+    public static boolean describes(EntityTag entity) {
+        return true;
+    }
+
+    @Override
+    public ElementTag getPropertyValue() {
+        return new ElementTag(getEntity().isSneaking());
+    }
+
+    @Override
+    public boolean isDefaultValue(ElementTag value) {
+        return !value.asBoolean();
+    }
+
+    @Override
+    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
+        if (!mechanism.requireBoolean()) {
+            return;
+        }
+        boolean sneaking = value.asBoolean();
+        getEntity().setSneaking(sneaking);
+        if (getEntity() == MinecraftClient.getInstance().player) {
+            KeyBindingMixinAccess keyBindingMixinAccess = (KeyBindingMixinAccess) MinecraftClient.getInstance().options.sneakKey;
+            keyBindingMixinAccess.forceSetPressed(sneaking);
+            keyBindingMixinAccess.disableUntilPress();
+        }
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "sneaking";
+    }
+
+    public static void register() {
+        autoRegister("sneaking", EntitySneaking.class, ElementTag.class, false);
+    }
+}

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/entity/EntitySneaking.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/entity/EntitySneaking.java
@@ -40,8 +40,8 @@ public class EntitySneaking extends EntityProperty<ElementTag> {
         getEntity().setSneaking(sneaking);
         if (getEntity() == MinecraftClient.getInstance().player) {
             KeyBindingMixinAccess keyBindingMixinAccess = (KeyBindingMixinAccess) MinecraftClient.getInstance().options.sneakKey;
-            keyBindingMixinAccess.forceSetPressed(sneaking);
-            keyBindingMixinAccess.disableUntilPress();
+            keyBindingMixinAccess.clientizen$forceSetPressed(sneaking);
+            keyBindingMixinAccess.clientizen$disableUntilPress();
         }
     }
 

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/entity/EntitySneaking.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/entity/EntitySneaking.java
@@ -10,7 +10,7 @@ public class EntitySneaking extends EntityProperty<ElementTag> {
 
     // <--[property]
     // @object EntityTag
-    // @name sneaking
+    // @name is_sneaking
     // @input ElementTag(Boolean)
     // @description
     // Whether an entity is sneaking.
@@ -47,10 +47,10 @@ public class EntitySneaking extends EntityProperty<ElementTag> {
 
     @Override
     public String getPropertyId() {
-        return "sneaking";
+        return "is_sneaking";
     }
 
     public static void register() {
-        autoRegister("sneaking", EntitySneaking.class, ElementTag.class, false);
+        autoRegister("is_sneaking", EntitySneaking.class, ElementTag.class, false);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/scripts/commands/ServerEventCommand.java
+++ b/src/main/java/com/denizenscript/clientizen/scripts/commands/ServerEventCommand.java
@@ -48,7 +48,7 @@ public class ServerEventCommand extends AbstractCommand {
     //     Denizen: scripting
     //     food: waffle
     //     loaded_entities: <client.loaded_entities.size>
-    // - customevent id:something_happened context:<[context]>
+    // - serverevent id:something_happened context:<[context]>
     //
     // -->
 

--- a/src/main/resources/clientizen.mixins.json
+++ b/src/main/resources/clientizen.mixins.json
@@ -10,6 +10,7 @@
     "MinecraftClientMixin",
     "IntPropertyAccessor",
     "ClientWorldAccessor",
+    "StickyKeyBindingAccessor",
     "gui.WScrollPanelAccessor",
     "gui.WTextAccessor"
   ],

--- a/src/main/resources/clientizen.mixins.json
+++ b/src/main/resources/clientizen.mixins.json
@@ -6,10 +6,11 @@
   "mixins": [],
   "client": [
     "ClientPlayNetworkHandlerMixin",
-    "KeyBindingMixin",
-    "MinecraftClientMixin",
-    "IntPropertyAccessor",
     "ClientWorldAccessor",
+    "IntPropertyAccessor",
+    "MinecraftClientMixin",
+    "EventKeyBindingMixin",
+    "SneakingKeyBindingMixin",
     "StickyKeyBindingAccessor",
     "gui.WScrollPanelAccessor",
     "gui.WTextAccessor"


### PR DESCRIPTION
## Additions

- `EntityTag.is_sneaking` property, with special handling to allow making the player see themselves as sneaking.
- `KeyBindingMixinAccess` (in a new `access` package) - an access interface for `KeyBindingMixin`.
- `KeyBindingMixinAccess#disableUntilPress` - disables the key until it's pressed, used to prevent the sneak key from being updated to `false` while fake-pressed in `EntityTag.sneaking`.
- `KeyBindingMixinAccess#forceSetPressed` - force-sets whether a key is pressed, as toggleable (sticky) key bindings have a different `KeyBinding#setPressed` impl.
- `KeyBindingMixin` is now `abstract` (better practice) and implements `KeyBindingMixinAccess`.
- `KeyBindingMixin.clientizen$disabled` - whether the key is disabled until pressed.
- `KeyBindingMixin#clientizen$onSetPressed` - inject into `KeyBinding#setPressed`, handles disabling it.
- `StickyKeyBindingAccessor` - an accessor Mixin to expose the `BooleanSupplier` which checks whether a toggleable (sticky) key binding is in `Toggle` mode.

## Changes

- Added "marker" comments to `KeyBindingMixin`, which make it easier to see which part is for what (as that Mixin has stuff for 2 different feature now).
- _**(Unrelated minor fix)**_ Fixed a typo in `ServerEventCommand`'s examples (`- customevent` -> `- serverevent`).

## Explanation
Tried several different stuff, but eventually went with setting the sneak key to pressed, as I ended up doing basically what I have right now just to make it work nicely with the sneak key, which made the previous handling redundant.
