### PR TITLE
Add `ModTag` and relevant tags

### DIFF
--- a/src/main/java/com/denizenscript/clientizen/objects/ClientizenObjectRegistry.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ClientizenObjectRegistry.java
@@ -9,11 +9,13 @@ public class ClientizenObjectRegistry {
     public static ObjectType<LocationTag> TYPE_LOCATION;
     public static ObjectType<MaterialTag> TYPE_MATERIAL;
     public static ObjectType<ItemTag> TYPE_ITEM;
+    public static ObjectType<ModTag> TYPE_MOD;
 
     public static void registerObjects() {
         TYPE_ENTITY = ObjectFetcher.registerWithObjectFetcher(EntityTag.class, EntityTag.tagProcessor).setAsNOtherCode().generateBaseTag();
         TYPE_LOCATION = ObjectFetcher.registerWithObjectFetcher(LocationTag.class, LocationTag.tagProcessor).setAsNOtherCode().setCanConvertStatic().generateBaseTag();
         TYPE_MATERIAL = ObjectFetcher.registerWithObjectFetcher(MaterialTag.class, MaterialTag.tagProcessor).generateBaseTag();
         TYPE_ITEM = ObjectFetcher.registerWithObjectFetcher(ItemTag.class, ItemTag.tagProcessor).setAsNOtherCode().generateBaseTag();
+        TYPE_MOD = ObjectFetcher.registerWithObjectFetcher(ModTag.class, ModTag.tagProcessor).setAsNOtherCode().setCanConvertStatic().generateBaseTag();
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
@@ -29,7 +29,7 @@ public class ModTag implements ObjectTag {
     // - narrate "The mod is %VALUE%!"
     // @format
     // The identity format for mods is the mod id.
-    // For example, 'mod@clientizen' or 'mod@purpur'.
+    // For example, 'mod@clientizen' or 'mod@purpeille'.
     //
     // @description
     // A ModTag represents a currently loaded fabric mod.

--- a/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
@@ -29,7 +29,7 @@ public class ModTag implements ObjectTag {
     // - narrate "The mod is %VALUE%!"
     // @format
     // The identity format for mods is the mod id.
-    // For example, 'mod@clientizen' or 'mod@purpeille'.
+    // For example, 'mod@clientizen' or 'mod@theprinter'.
     //
     // @description
     // A ModTag represents a currently loaded fabric mod.

--- a/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
@@ -1,0 +1,247 @@
+package com.denizenscript.clientizen.objects;
+
+import com.denizenscript.clientizen.util.Utilities;
+import com.denizenscript.denizencore.events.ScriptEvent;
+import com.denizenscript.denizencore.objects.Fetchable;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
+import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.tags.ObjectTagProcessor;
+import com.denizenscript.denizencore.tags.TagContext;
+import com.denizenscript.denizencore.utilities.CoreUtilities;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+
+import java.util.Optional;
+
+public class ModTag implements ObjectTag {
+
+    // <--[ObjectType]
+    // @name ModTag
+    // @prefix mod
+    // @base ElementTag
+    // @ExampleTagBase mod[clientizen]
+    // @ExampleValues <mod[clientizen]>
+    // @ExampleForReturns
+    // - narrate "The mod is %VALUE%!"
+    // @format
+    // The identity format for mods is the mod ID.
+    // For example, 'mod@clientizen' or 'mod@purpur'.
+    //
+    // @description
+    // A ModTag represents a currently loaded fabric mod.
+    //
+    // This can be either a mod that's been downloaded and installed, a built-in mod, or a mod-within-mod (a library mod, for example)
+    //
+    // -->
+
+    @Fetchable("mod")
+    public static ModTag valueOf(String input, TagContext context) {
+        if (input.startsWith("mod@")) {
+            input = input.substring("mod@".length());
+        }
+        Optional<ModTag> modTag = FabricLoader.getInstance().getModContainer(CoreUtilities.toLowerCase(input)).map(ModTag::new);
+        if (modTag.isEmpty()) {
+            Utilities.echoErrorByContext(context, "valueOf ModTag returning null: '" + input + "' isn't a valid mod name.");
+            return null;
+        }
+        return modTag.get();
+    }
+
+    public static boolean matches(String string) {
+        if (string.startsWith("mod@")) {
+            return true;
+        }
+        return FabricLoader.getInstance().isModLoaded(CoreUtilities.toLowerCase(string));
+    }
+
+    public final ModContainer modContainer;
+
+    public ModTag(ModContainer modContainer) {
+        this.modContainer = modContainer;
+    }
+
+    public ModMetadata getMetadata() {
+        return modContainer.getMetadata();
+    }
+
+    public static void register() {
+
+        // <--[tag]
+        // @attribute <ModTag.id>
+        // @returns ElementTag
+        // @description
+        // Returns a mod's id.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "id", (attribute, object) -> {
+            return new ElementTag(object.getMetadata().getId(), true);
+        });
+
+        // <--[tag]
+        // @attribute <ModTag.display_name>
+        // @returns ElementTag
+        // @description
+        // Returns a mod's display name.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "display_name", (attribute, object) -> {
+            return new ElementTag(object.getMetadata().getName(), true);
+        });
+
+        // <--[tag]
+        // @attribute <ModTag.description>
+        // @returns ElementTag
+        // @description
+        // Returns a mod's description.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "description", (attribute, object) -> {
+            return new ElementTag(object.getMetadata().getDescription(), true);
+        });
+
+        // <--[tag]
+        // @attribute <ModTag.version>
+        // @returns ElementTag
+        // @description
+        // Returns a mod's version.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "version", (attribute, object) -> {
+            return new ElementTag(object.getMetadata().getVersion().getFriendlyString(), true);
+        });
+
+        // <--[tag]
+        // @attribute <ModTag.authors>
+        // @returns MapTag
+        // @description
+        // Returns a mod's authors, as a map of author name to their contact information.
+        // The contact information is a map of contact platforms to identification on that platform.
+        // Note that mods can provide anything here, although most mods will obviously provide valid info.
+        // -->
+        tagProcessor.registerTag(MapTag.class, "authors", (attribute, object) -> {
+            return Utilities.personsToMap(object.getMetadata().getAuthors());
+        });
+
+        // <--[tag]
+        // @attribute <ModTag.contributors>
+        // @returns MapTag
+        // @description
+        // Returns a mod's contributors, as a map of contributor name to their contact information.
+        // The contact information is a map of contact platforms to identification on that platform.
+        // Note that mods can provide anything here, although most mods will obviously provide valid info.
+        // -->
+        tagProcessor.registerTag(MapTag.class, "contributors", (attribute, object) -> {
+            return Utilities.personsToMap(object.getMetadata().getContributors());
+        });
+
+        // <--[tag]
+        // @attribute <ModTag.contact_info>
+        // @returns MapTag
+        // @description
+        // Returns a mod's contact information, as a map of contact platforms to identification on that platform.
+        // Note that mods can provide anything here, although most mods will obviously provide valid info.
+        // -->
+        tagProcessor.registerTag(MapTag.class, "contact_info", (attribute, object) -> {
+            return Utilities.contactInfoToMap(object.getMetadata().getContact());
+        });
+
+        // <--[tag]
+        // @attribute <ModTag.licenses>
+        // @returns ListTag
+        // @description
+        // Returns a list of a mod's licenses.
+        // -->
+        tagProcessor.registerTag(ListTag.class, "licenses", (attribute, object) -> {
+            return new ListTag(object.getMetadata().getLicense(), true);
+        });
+
+        // <--[tag]
+        // @attribute <ModTag.type>
+        // @returns ElementTag
+        // @description
+        // Returns a mod's type, either 'fabric' or 'builtin'.
+        // -->
+        tagProcessor.registerTag(ElementTag.class, "type", (attribute, object) -> {
+            return new ElementTag(object.getMetadata().getType(), true);
+        });
+
+        // <--[tag]
+        // @attribute <ModTag.containing_mod>
+        // @returns ModTag
+        // @description
+        // Returns the mod that contains this mod, if any (for things like library mods included by other mods).
+        // -->
+        tagProcessor.registerTag(ModTag.class, "containing_mod", (attribute, object) -> {
+            return object.modContainer.getContainingMod().map(ModTag::new).orElse(null);
+        });
+
+        // <--[tag]
+        // @attribute <ModTag.contained_mods>
+        // @returns ListTag(ModTag)
+        // @description
+        // Returns a list of mods contained by this mod (for mods that include libraries, for example).
+        // -->
+        tagProcessor.registerTag(ListTag.class, "contained_mods", (attribute, object) -> {
+            return new ListTag(object.modContainer.getContainedMods(), ModTag::new);
+        });
+    }
+
+    public static final ObjectTagProcessor<ModTag> tagProcessor = new ObjectTagProcessor<>();
+
+    @Override
+    public ObjectTag getObjectAttribute(Attribute attribute) {
+        return tagProcessor.getObjectAttribute(this, attribute);
+    }
+
+    @Override
+    public String identify() {
+        return "mod@" + getMetadata().getId();
+    }
+
+    @Override
+    public String debuggable() {
+        return "<LG>mod@<Y>" + getMetadata().getId();
+    }
+
+    @Override
+    public String identifySimple() {
+        return identify();
+    }
+
+    @Override
+    public String toString() {
+        return identify();
+    }
+
+    @Override
+    public Object getJavaObject() {
+        return modContainer;
+    }
+
+    @Override
+    public boolean advancedMatches(String matcher) {
+        String matcherLower = CoreUtilities.toLowerCase(matcher);
+        if (matcherLower.equals("mod")) {
+            return true;
+        }
+        return ScriptEvent.runGenericCheck(matcherLower, getMetadata().getId());
+    }
+
+    @Override
+    public boolean isUnique() {
+        return true;
+    }
+
+    String prefix = "Mod";
+
+    @Override
+    public String getPrefix() {
+        return prefix;
+    }
+
+    @Override
+    public ObjectTag setPrefix(String prefix) {
+        this.prefix = prefix;
+        return this;
+    }
+}

--- a/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
@@ -218,7 +218,7 @@ public class ModTag implements ObjectTag {
     }
 
     @Override
-    public Object getJavaObject() {
+    public ModContainer getJavaObject() {
         return modContainer;
     }
 

--- a/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
@@ -32,9 +32,9 @@ public class ModTag implements ObjectTag {
     // For example, 'mod@clientizen' or 'mod@theprinter'.
     //
     // @description
-    // A ModTag represents a currently loaded fabric mod.
+    // A ModTag represents a currently loaded mod.
     //
-    // This can be either a mod that's been downloaded and installed, a built-in mod, or a mod-within-mod (a library mod, for example)
+    // This can be either a mod that's been downloaded and installed, a built-in mod, or a mod within another mod (a library mod, for example)
     //
     // @Matchable
     // ModTag matchers:
@@ -49,7 +49,7 @@ public class ModTag implements ObjectTag {
         }
         Optional<ModTag> modTag = FabricLoader.getInstance().getModContainer(CoreUtilities.toLowerCase(input)).map(ModTag::new);
         if (modTag.isEmpty()) {
-            Utilities.echoErrorByContext(context, "valueOf ModTag returning null: '" + input + "' isn't a valid mod name.");
+            Utilities.echoErrorByContext(context, "valueOf ModTag returning null: '" + input + "' isn't a valid mod id.");
             return null;
         }
         return modTag.get();
@@ -143,6 +143,7 @@ public class ModTag implements ObjectTag {
         // @returns MapTag
         // @description
         // Returns a mod's contact information, as a map of contact platforms to identification on that platform.
+        // Some common examples are: "repo", "website", "issues", etc.
         // Note that mods can provide anything here, although most mods will obviously provide valid info.
         // -->
         tagProcessor.registerStaticTag(MapTag.class, "contact_info", (attribute, object) -> {
@@ -163,7 +164,9 @@ public class ModTag implements ObjectTag {
         // @attribute <ModTag.type>
         // @returns ElementTag
         // @description
-        // Returns a mod's type, either 'fabric' or 'builtin'.
+        // Returns a mod's type, either:
+        //  'fabric' - a regular Fabric mod, either directly installed or included by another mod.
+        //  'builtin' - a built-in mod, generally used for internal mods included by Fabric itself.
         // -->
         tagProcessor.registerStaticTag(ElementTag.class, "type", (attribute, object) -> {
             return new ElementTag(object.getMetadata().getType(), true);

--- a/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
@@ -80,7 +80,7 @@ public class ModTag implements ObjectTag {
         // @description
         // Returns a mod's id.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "id", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ElementTag.class, "id", (attribute, object) -> {
             return new ElementTag(object.getMetadata().getId(), true);
         });
 
@@ -90,7 +90,7 @@ public class ModTag implements ObjectTag {
         // @description
         // Returns a mod's display name.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "display_name", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ElementTag.class, "display_name", (attribute, object) -> {
             return new ElementTag(object.getMetadata().getName(), true);
         });
 
@@ -100,7 +100,7 @@ public class ModTag implements ObjectTag {
         // @description
         // Returns a mod's description.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "description", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ElementTag.class, "description", (attribute, object) -> {
             return new ElementTag(object.getMetadata().getDescription(), true);
         });
 
@@ -110,7 +110,7 @@ public class ModTag implements ObjectTag {
         // @description
         // Returns a mod's version.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "version", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ElementTag.class, "version", (attribute, object) -> {
             return new ElementTag(object.getMetadata().getVersion().getFriendlyString(), true);
         });
 
@@ -122,7 +122,7 @@ public class ModTag implements ObjectTag {
         // The contact information is a map of contact platforms to identification on that platform.
         // Note that mods can provide anything here, although most mods will obviously provide valid info.
         // -->
-        tagProcessor.registerTag(MapTag.class, "authors", (attribute, object) -> {
+        tagProcessor.registerStaticTag(MapTag.class, "authors", (attribute, object) -> {
             return Utilities.personsToMap(object.getMetadata().getAuthors());
         });
 
@@ -134,7 +134,7 @@ public class ModTag implements ObjectTag {
         // The contact information is a map of contact platforms to identification on that platform.
         // Note that mods can provide anything here, although most mods will obviously provide valid info.
         // -->
-        tagProcessor.registerTag(MapTag.class, "contributors", (attribute, object) -> {
+        tagProcessor.registerStaticTag(MapTag.class, "contributors", (attribute, object) -> {
             return Utilities.personsToMap(object.getMetadata().getContributors());
         });
 
@@ -145,7 +145,7 @@ public class ModTag implements ObjectTag {
         // Returns a mod's contact information, as a map of contact platforms to identification on that platform.
         // Note that mods can provide anything here, although most mods will obviously provide valid info.
         // -->
-        tagProcessor.registerTag(MapTag.class, "contact_info", (attribute, object) -> {
+        tagProcessor.registerStaticTag(MapTag.class, "contact_info", (attribute, object) -> {
             return Utilities.contactInfoToMap(object.getMetadata().getContact());
         });
 
@@ -155,7 +155,7 @@ public class ModTag implements ObjectTag {
         // @description
         // Returns a list of a mod's licenses.
         // -->
-        tagProcessor.registerTag(ListTag.class, "licenses", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ListTag.class, "licenses", (attribute, object) -> {
             return new ListTag(object.getMetadata().getLicense(), true);
         });
 
@@ -165,7 +165,7 @@ public class ModTag implements ObjectTag {
         // @description
         // Returns a mod's type, either 'fabric' or 'builtin'.
         // -->
-        tagProcessor.registerTag(ElementTag.class, "type", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ElementTag.class, "type", (attribute, object) -> {
             return new ElementTag(object.getMetadata().getType(), true);
         });
 
@@ -175,7 +175,7 @@ public class ModTag implements ObjectTag {
         // @description
         // Returns the mod that contains this mod, if any (for things like library mods included by other mods).
         // -->
-        tagProcessor.registerTag(ModTag.class, "containing_mod", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ModTag.class, "containing_mod", (attribute, object) -> {
             return object.modContainer.getContainingMod().map(ModTag::new).orElse(null);
         });
 
@@ -185,7 +185,7 @@ public class ModTag implements ObjectTag {
         // @description
         // Returns a list of mods contained by this mod (for mods that include libraries, for example).
         // -->
-        tagProcessor.registerTag(ListTag.class, "contained_mods", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ListTag.class, "contained_mods", (attribute, object) -> {
             return new ListTag(object.modContainer.getContainedMods(), ModTag::new);
         });
     }

--- a/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ModTag.java
@@ -28,7 +28,7 @@ public class ModTag implements ObjectTag {
     // @ExampleForReturns
     // - narrate "The mod is %VALUE%!"
     // @format
-    // The identity format for mods is the mod ID.
+    // The identity format for mods is the mod id.
     // For example, 'mod@clientizen' or 'mod@purpur'.
     //
     // @description
@@ -36,6 +36,10 @@ public class ModTag implements ObjectTag {
     //
     // This can be either a mod that's been downloaded and installed, a built-in mod, or a mod-within-mod (a library mod, for example)
     //
+    // @Matchable
+    // ModTag matchers:
+    // "mod" plaintext: always matches.
+    // Mod id: matches if the mod id matches the input, using advanced matchers.
     // -->
 
     @Fetchable("mod")

--- a/src/main/java/com/denizenscript/clientizen/tags/ClientTagBase.java
+++ b/src/main/java/com/denizenscript/clientizen/tags/ClientTagBase.java
@@ -14,8 +14,6 @@ import com.denizenscript.denizencore.scripts.commands.core.AdjustCommand;
 import com.denizenscript.denizencore.tags.PseudoObjectTagBase;
 import com.denizenscript.denizencore.tags.TagManager;
 import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.impl.FabricLoaderImpl;
-import net.fabricmc.loader.impl.metadata.AbstractModMetadata;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.hit.BlockHitResult;
@@ -55,8 +53,8 @@ public class ClientTagBase extends PseudoObjectTagBase<ClientTagBase> {
         // -->
         tagProcessor.registerStaticTag(ListTag.class, "mods", (attribute, object) -> {
             return new ListTag(FabricLoader.getInstance().getAllMods(),
-                    modContainer -> modContainer.getContainingMod().isEmpty() && modContainer.getMetadata().getType().equals(AbstractModMetadata.TYPE_FABRIC_MOD)
-                            && !modContainer.getMetadata().getId().equals(FabricLoaderImpl.MOD_ID),
+                    modContainer -> modContainer.getContainingMod().isEmpty() && modContainer.getMetadata().getType().equals("fabric")
+                            && !modContainer.getMetadata().getId().equals("fabricloader"),
                     ModTag::new);
         });
 

--- a/src/main/java/com/denizenscript/clientizen/tags/ClientTagBase.java
+++ b/src/main/java/com/denizenscript/clientizen/tags/ClientTagBase.java
@@ -3,6 +3,7 @@ package com.denizenscript.clientizen.tags;
 import com.denizenscript.clientizen.objects.EntityTag;
 import com.denizenscript.clientizen.objects.LocationTag;
 import com.denizenscript.clientizen.objects.MaterialTag;
+import com.denizenscript.clientizen.objects.ModTag;
 import com.denizenscript.denizencore.DenizenCore;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
@@ -12,6 +13,9 @@ import com.denizenscript.denizencore.objects.core.TimeTag;
 import com.denizenscript.denizencore.scripts.commands.core.AdjustCommand;
 import com.denizenscript.denizencore.tags.PseudoObjectTagBase;
 import com.denizenscript.denizencore.tags.TagManager;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.impl.FabricLoaderImpl;
+import net.fabricmc.loader.impl.metadata.AbstractModMetadata;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.hit.BlockHitResult;
@@ -41,6 +45,29 @@ public class ClientTagBase extends PseudoObjectTagBase<ClientTagBase> {
                 entities.addObject(new EntityTag(entity));
             }
             return entities;
+        });
+
+        // <--[tag]
+        // @attribute <client.mods>
+        // @returns ListTag(ModTag)
+        // @description
+        // Returns a list of all currently loaded mods (this doesn't include things like mods-within-mods or built-in mods).
+        // -->
+        tagProcessor.registerTag(ListTag.class, "mods", (attribute, object) -> {
+            return new ListTag(FabricLoader.getInstance().getAllMods(),
+                    modContainer -> modContainer.getContainingMod().isEmpty() && modContainer.getMetadata().getType().equals(AbstractModMetadata.TYPE_FABRIC_MOD)
+                            && !modContainer.getMetadata().getId().equals(FabricLoaderImpl.MOD_ID),
+                    ModTag::new);
+        });
+
+        // <--[tag]
+        // @attribute <client.all_mods>
+        // @returns ListTag(ModTag)
+        // @description
+        // Returns a list of all currently loaded mods, including mods-within-mods and built-in mods.
+        // -->
+        tagProcessor.registerTag(ListTag.class, "all_mods", (attribute, object) -> {
+            return new ListTag(FabricLoader.getInstance().getAllMods(), ModTag::new);
         });
 
         // <--[tag]

--- a/src/main/java/com/denizenscript/clientizen/tags/ClientTagBase.java
+++ b/src/main/java/com/denizenscript/clientizen/tags/ClientTagBase.java
@@ -53,7 +53,7 @@ public class ClientTagBase extends PseudoObjectTagBase<ClientTagBase> {
         // @description
         // Returns a list of all currently loaded mods (this doesn't include things like mods-within-mods or built-in mods).
         // -->
-        tagProcessor.registerTag(ListTag.class, "mods", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ListTag.class, "mods", (attribute, object) -> {
             return new ListTag(FabricLoader.getInstance().getAllMods(),
                     modContainer -> modContainer.getContainingMod().isEmpty() && modContainer.getMetadata().getType().equals(AbstractModMetadata.TYPE_FABRIC_MOD)
                             && !modContainer.getMetadata().getId().equals(FabricLoaderImpl.MOD_ID),
@@ -66,7 +66,7 @@ public class ClientTagBase extends PseudoObjectTagBase<ClientTagBase> {
         // @description
         // Returns a list of all currently loaded mods, including mods-within-mods and built-in mods.
         // -->
-        tagProcessor.registerTag(ListTag.class, "all_mods", (attribute, object) -> {
+        tagProcessor.registerStaticTag(ListTag.class, "all_mods", (attribute, object) -> {
             return new ListTag(FabricLoader.getInstance().getAllMods(), ModTag::new);
         });
 

--- a/src/main/java/com/denizenscript/clientizen/util/Utilities.java
+++ b/src/main/java/com/denizenscript/clientizen/util/Utilities.java
@@ -1,11 +1,16 @@
 package com.denizenscript.clientizen.util;
 
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.core.MapTag;
 import com.denizenscript.denizencore.tags.TagContext;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.fabricmc.loader.api.metadata.ContactInformation;
+import net.fabricmc.loader.api.metadata.Person;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
 import java.util.UUID;
 
 public class Utilities {
@@ -29,5 +34,21 @@ public class Utilities {
         if (context == null || context.showErrors()) {
             Debug.echoError(error);
         }
+    }
+
+    public static MapTag contactInfoToMap(ContactInformation contactInformation) {
+        MapTag contact = new MapTag();
+        for (Map.Entry<String, String> entry : contactInformation.asMap().entrySet()) {
+            contact.putObject(entry.getKey(), new ElementTag(entry.getValue(), true));
+        }
+        return contact;
+    }
+
+    public static MapTag personsToMap(Iterable<Person> persons) {
+        MapTag personsMap = new MapTag();
+        for (Person person : persons) {
+            personsMap.putObject(person.getName(), contactInfoToMap(person.getContact()));
+        }
+        return personsMap;
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -6,12 +6,7 @@
   "description": "Run Denizen scripts on the client with platform-specific features",
   "authors": [
     "The Denizen Script team",
-    {
-      "name": "Aya",
-      "contact": {
-        "discord": "ayalaandtal"
-      }
-    },
+    "Aya",
     "acikek"
   ],
   "contact": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -6,7 +6,12 @@
   "description": "Run Denizen scripts on the client with platform-specific features",
   "authors": [
     "The Denizen Script team",
-    "Aya",
+    {
+      "name": "Aya",
+      "contact": {
+        "discord": "ayalaandtal"
+      }
+    },
     "acikek"
   ],
   "contact": {


### PR DESCRIPTION
## Additions

- `ModTag` object type - represents a loaded fabric mod.
- All of the basics for `ModTag` - tags, meta, advanced matching format, etc.
- `client.mods` - returns a list of a client's installed mods (basically what you'd expect such a tag to return, just what the user actually installed), mainly a util tag that does the filtering for you.
- `client.all_mods` - returns every single loaded mod, including library mods, built-in, etc.
- `Utilities#contactInfoToMap` - does what it says; used by some `ModTag` tags.
- `Utilities#personsToMap` - converts a list of `Person` objects to a map; used by some `ModTag` tags.

## Notes

- Everything is static currently, as correct me if I'm wrong but I don't believe mods can be loaded/unloaded/have info changed dynamically?
- Some of the meta feels a little short (I.e. just `Returns a mod's id.`), but I'm not really sure what to add three.